### PR TITLE
Make HTTP request timeout configurable via parameter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,27 @@
 
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ad8f9ab7c65131f3fcad87fdf82d7414d6d80fb0dda6f41711c2cee907f4511e"
+  input-imports = [
+    "github.com/pkg/errors",
+    "github.com/urfave/cli",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/commands/execute.go
+++ b/commands/execute.go
@@ -30,6 +30,11 @@ func init() {
 				Name:  "file-payload",
 				Usage: "path to file which is used as payload argument for execution (json format)",
 			},
+			cli.IntFlag{
+				Name: "timeout",
+				Usage: "timeout for HTTP client requests",
+				Value: 30,
+			},
 		},
 	})
 }
@@ -40,6 +45,8 @@ func Execute(context *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	manager.WithTimeout(context.Int("timeout"))
 
 	filename := context.Args().First()
 	if filename == "" {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-
 	"time"
 
 	"github.com/pkg/errors"
@@ -35,6 +34,10 @@ type Manager struct {
 	password      string
 
 	client *http.Client
+}
+
+func (manager *Manager) WithTimeout(timeoutInSeconds int) {
+	manager.client.Timeout = time.Second * time.Duration(timeoutInSeconds)
 }
 
 // Get returns a script instance of the given name


### PR DESCRIPTION
HTTP request timeout is configurable via `--timeout` parameter, 
e.g. `nexus-scripting execute --timeout 60 ...`
The default timeout is set to 30 seconds.